### PR TITLE
Use nannou crate instead of local installation path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,8 @@ dependencies = [
 [[package]]
 name = "nannou"
 version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1597e2d8e913ea08ae0d0009a25dea726ff6de1d48e71d2aaae9328d41a69afb"
 dependencies = [
  "cgmath",
  "conrod_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nannou = { version ="0.15.0", path = "../nannou/nannou" }
+nannou = "0.15"


### PR DESCRIPTION
Uses the `nannou` crate so that people don't have to manually download nannou.